### PR TITLE
No Jira - Update scala tagging to handle hotfix tags

### DIFF
--- a/.github/workflows/tag-debs.yml
+++ b/.github/workflows/tag-debs.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Bump version and push tag
-        if: ${{ github.ref != 'refs/tags/*' }}
+        if: ${{ github.ref_type != 'tag' }}
         uses: otrl/github-tag-action@v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
@@ -71,7 +71,7 @@ jobs:
       - name: Determine tag or version
         id: determine-tag
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "${{ github.ref_type }}" == 'tag' ]]; then
             echo "GIT_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
           else
             echo "GIT_TAG=`echo $(git tag --sort=committerdate | tail -1)`" >> $GITHUB_ENV
@@ -112,7 +112,7 @@ jobs:
           docker push ${{ inputs.repo_name }}:$GIT_TAG
 
       - name: Create release
-        if: ${{ github.ref != 'refs/tags/*' }}
+        if: ${{ github.ref_type != 'tag' }}
         uses: otrl/github-release-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/.github/workflows/tag-debs.yml
+++ b/.github/workflows/tag-debs.yml
@@ -51,6 +51,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Bump version and push tag
+        if: ${{ github.ref != 'refs/tags/*' }}
         uses: otrl/github-tag-action@v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
@@ -66,14 +67,20 @@ jobs:
 
       - name: Setup sbt launcher
         uses: sbt/setup-sbt@v1
-        
-      - name: set docker tag
-        run: echo "GIT_TAG=`echo $(git tag --sort=committerdate | tail -1)`" >> $GITHUB_ENV
+
+      - name: Determine tag or version
+        id: determine-tag
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "GIT_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "GIT_TAG=`echo $(git tag --sort=committerdate | tail -1)`" >> $GITHUB_ENV
+          fi
 
       - name: set package version
         run: |
           set -e
-          echo "DEBVERSION=`echo $(git tag --sort=committerdate | tail -1)`" >> $GITHUB_ENV
+          echo "DEBVERSION=$GIT_TAG" >> $GITHUB_ENV
 
       - name: edit the build file
         run: sed -i "s/LATEST/$DEBVERSION/g" /home/runner/work/${{ inputs.service_name }}/${{ inputs.service_name }}/build.sbt
@@ -105,6 +112,7 @@ jobs:
           docker push ${{ inputs.repo_name }}:$GIT_TAG
 
       - name: Create release
+        if: ${{ github.ref != 'refs/tags/*' }}
         uses: otrl/github-release-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/.github/workflows/tag-java-scala-docker.yml
+++ b/.github/workflows/tag-java-scala-docker.yml
@@ -49,6 +49,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Bump version and push tag
+        if: ${{ github.ref_type != 'tag' }}
         uses: otrl/github-tag-action@v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
@@ -70,8 +71,13 @@ jobs:
           set -e
           sbt ++${{ inputs.scala_version }} clean test docker:publishLocal
 
-      - name: set docker tag
-        run: echo "GIT_TAG=`echo $(git tag --sort=committerdate | tail -1)`" >> "$GITHUB_ENV"
+      - name: Determine tag or version
+        run: |
+          if [[ "${{ github.ref_type }}" == 'tag' ]]; then
+            echo "GIT_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "GIT_TAG=`echo $(git tag --sort=committerdate | tail -1)`" >> $GITHUB_ENV
+          fi      
 
 #      - name: Configure AWS credentials
 #        uses: aws-actions/configure-aws-credentials@v4
@@ -109,6 +115,7 @@ jobs:
           docker push ${{ inputs.repo_name }}:$GIT_TAG
 
       - name: Create release
+        if: ${{ github.ref_type != 'tag' }}
         uses: otrl/github-release-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}


### PR DESCRIPTION

### The problem
There is no way with our current auto tagging to tag a hotfix, that is where a tag is created from a previous tag.

### What's been done
- [x] Update tagging to handle hotfix tags: `x.x.x-x`
- [x] Bypasses auto tagging and uses to tag ref based on the branch
- [x] Bypasses release notes as this uses master

### Steps to create a hotfix tag

- Checkout tag version you want  (`1.2.3`)
- Cherry-pick you change onto the tag
- Create a new tag in the format (`1.2.3-1`)
- Push tags to repo
- Go to repo actions
- Find tag builders
- Manually run tag builder on the new tag you just created (`1.2.3-1`)

   

### Test
Ran a test tag on a old cocs tag:
![Screenshot 2025-04-09 at 14 31 51](https://github.com/user-attachments/assets/88147375-b2e2-42ba-bc2f-47e17635030f)
![Screenshot 2025-04-09 at 14 31 45](https://github.com/user-attachments/assets/995434eb-b9e7-436b-aaf3-3eacd997a8ff)




